### PR TITLE
Add prettierrc file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"bracketSpacing": true,
+	"printWidth": 120,
+	"semi": false,
+	"singleQuote": true,
+	"tabWidth": 4,
+	"trailingComma": "es5",
+	"useTabs": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # eslint-config-bdc
-our rules for eslint in a reusable config
+
+business.com engineering team's eslint setup via reusable NPM package.
+
+
+This eslint config extends [this create react app one](https://github.com/facebook/create-react-app/tree/master/packages/eslint-config-react-app)
+and adds [prettier](https://prettier.io/docs/en/integrating-with-linters.html) formatting to it with some additional rules we standardized around at business.com.
+
+## Install:
+
+#### Step 1: Install the config and all of it's peer deps:
+```
+yarn add -D @bizdotcom/eslint-config-bdc eslint-config-react-app @typescript-eslint/eslint-plugin@2.x @typescript-eslint/parser@2.x babel-eslint@10.x eslint@6.x eslint-plugin-flowtype@3.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.x prettier eslint-plugin-prettier
+
+or
+
+npm install -D @bizdotcom/eslint-config-bdc eslint-config-react-app @typescript-eslint/eslint-plugin@2.x @typescript-eslint/parser@2.x babel-eslint@10.x eslint@6.x eslint-plugin-flowtype@3.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.x prettier eslint-plugin-prettier
+```
+
+#### Step 2: Create a file named `.eslintrc.json` with following contents in the root folder of your project:
+
+```
+{
+  "extends": "@bizdotcom/eslint-config-bdc"
+}
+```
+
+## Use:
+
+There are many ways you can run eslint. Here are a few suggestions:
+
+1. Run eslint in your code editor of choice via eslint extension.
+	- [vscode eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+		- **(Recommended)** eslint can do more than just lint, especially the way we have it configured.
+		To automate some of the fixable errors/warnings and the prettier code formatting
+		we recommend that you enable this setting to make eslint run as soon as you hit
+		save. Add this to your settings.json:
+			```
+			"editor.codeActionsOnSave": {
+				"source.fixAll.eslint": true
+			}
+			```
+	- [sublime eslint extension](https://github.com/SublimeLinter/SublimeLinter-eslint)
+	- and many more can be [found here](https://eslint.org/docs/user-guide/integrations#editors)
+
+
+2. An NPM script in your package.json: `"lint": "eslint --ext .js,.jsx ./src"`
+	- optionally you could also add a script which runs the fix command for you: `"lint-fix": "yarn run lint --fix"`
+	- you could have these script run on commit-hooks with help from tools like [husky](https://github.com/typicode/husky)
+	or watch your files and run on save via build tools like webpack, gulp, or eslint-watch etc.
+
+3. Like we said, these are just our suggested methods, we know there are others, you're welcome to use whichever method
+works best for you!
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019-present, Business.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ module.exports = {
+	"extends": "react-app",
+	"plugins": ["prettier"],
+	"rules": {
+		"prettier/prettier": [
+			"error",
+			{
+				"bracketSpacing": true,
+				"printWidth": 120,
+				"semi": false,
+				"singleQuote": true,
+				"tabWidth": 4,
+				"trailingComma": "es5",
+				"useTabs": true,
+			}
+		],
+		"import/no-unresolved": [2, {"commonjs": true, "amd": true}],
+		"import/named": 2,
+		"import/namespace": 2,
+		"import/default": 2,
+		"import/export": 2,
+	},
+	"settings": {
+		"import/resolver": {
+			"node": {
+				"extensions": [
+					".js",
+					".jsx"
+				]
+			}
+		}
+	},
+}
+
+
+// for ref: https://codingsrc.com/eslint-prettier-create-react-app-best-configuration-setup-2019/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bizdotcom/eslint-config-bdc",
+  "version": "1.0.0",
+  "description": "eslint config for business.com, businessnewsdaily.com, buyerzone.com and other related projects",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/businessdotcom/eslint-config-bdc.git"
+  },
+  "keywords": [
+    "eslint",
+    "config",
+    "javascript",
+    "code",
+    "style",
+    "linting"
+  ],
+  "author": "BDC Dev Garage",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/businessdotcom/eslint-config-bdc/issues"
+  },
+  "homepage": "https://github.com/businessdotcom/eslint-config-bdc#readme",
+  "peerDependencies": {
+      "eslint": ">= 3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "eslint config for business.com, businessnewsdaily.com, buyerzone.com and other related projects",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "publishPublic": "npm publish --access public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bizdotcom/eslint-config-bdc",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "eslint config for business.com, businessnewsdaily.com, buyerzone.com and other related projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "style",
     "linting"
   ],
-  "author": "BDC Dev Garage",
+  "author": "BDC Dev Garage (gh:@businessdotcom t:@bdc_dev_garage)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/businessdotcom/eslint-config-bdc/issues"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "homepage": "https://github.com/businessdotcom/eslint-config-bdc#readme",
   "peerDependencies": {
-      "eslint": ">= 3"
+    "eslint": ">= 3",
+    "eslint-config-react-app": ">= 5",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,7 @@
     "eslint-config-react-app": ">= 5",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1"
-  }
+  },
+  "dependencies": {},
+  "devDependencies": {}
 }


### PR DESCRIPTION
Without this vscode wasn't adding double quotes, semis, causing linting errors later. I thought it makes sense to have a downloadable config to match rules.